### PR TITLE
Bug fix backward compatibility

### DIFF
--- a/app/src/main/res/drawable/roundedbutton.xml
+++ b/app/src/main/res/drawable/roundedbutton.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:dither="true"
+    android:shape="oval">
+
+    <solid android:color="@color/colorPrimary"/>
+
+</shape>


### PR DESCRIPTION
### Proposal to solve the app crash with API level lower than 24
Added drawable/roundedbutton.xlm which is a copy of drawable-v24/roundedbutton.xml
### Executed Tests
* API 21 (Android version 5.0.1), physical device, Samsung Galaxy S4 GT-I9505
* API 28, emulator, Pixel